### PR TITLE
Parameterize candidate_name and count for funding_sources SQL request

### DIFF
--- a/django/congressionaldata/api/views.py
+++ b/django/congressionaldata/api/views.py
@@ -30,7 +30,7 @@ def funding_sources(request, candidate_name, count):
         WHERE recipient_candidate_name LIKE %s
         GROUP BY donor_name
         ORDER BY sum DESC LIMIT %s
-        """, ["%%%s%%" % candidate_name.upper(), str(count)])
+        """, params = (["%%%s%%" % candidate_name.upper(), str(count)]))
     sources = []
     for source in funding_source_query:
         sources.append({


### PR DESCRIPTION
**1. Prevent SQL injection in raw SQL funding_sources query by parameterizing request.**



**2. Link to Trello Ticket: None at the moment**



**3. This parameterization will need to be applied to all SQL request models to guard against SQL injection vulnerabilities.**



**4. Remember to tag reviewers!**